### PR TITLE
add comonad >= 4.0 to deps

### DIFF
--- a/haarss.cabal
+++ b/haarss.cabal
@@ -15,11 +15,11 @@ cabal-version:       >=1.8
 executable haarss
   main-is:       Main.hs
   other-modules: Feeds, Fetching, Model, View
-  build-depends: base >= 4.2 && < 4.8, 
-                 mtl >= 2.1.1 && < 2.2, 
+  build-depends: base >= 4.2 && < 4.8,
+                 mtl >= 2.1.1 && < 2.2,
                  containers >= 0.1 && < 0.6,
                  array >= 0.1 && < 0.6,
-                 stm >= 2.2.0.0 && < 2.4.3, 
+                 stm >= 2.2.0.0 && < 2.4.3,
                  QuickCheck >= 2.5 && < 2.8,
                  unix >= 2.5.0.0 && < 2.8,
                  process >= 1.1 && < 1.3,
@@ -30,5 +30,6 @@ executable haarss
                  vty >= 4.7 && < 5,
                  feed ==0.3.*,
                  lens >= 3.10.0 && < 4.5,
-                 sodium ==0.10.*
+                 sodium ==0.10.*,
+                 comonad >= 4.0
   ghc-options:   -Wall -fno-warn-unused-do-bind


### PR DESCRIPTION
Fixes this build issue I had.

``` shell
Feeds.hs:15:8:
    Could not find module `Control.Comonad'
    It is a member of the hidden package `comonad-4.0'.
    Perhaps you need to add `comonad' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```
